### PR TITLE
Override minified showInAppMessage() function.

### DIFF
--- a/addon/instance-initializers/appboy.js
+++ b/addon/instance-initializers/appboy.js
@@ -32,7 +32,13 @@ export function initialize(appInstance) {
 
     const _superShowInAppMessage = appboy.display.showInAppMessage;
 
-    appboy.display.showInAppMessage = function(inAppMessage) {
+    // Since appboy does not expose an un-minified version of their SDK,
+    // the inner triggers to show in app messages will refer to the minified
+    // function name. Here we look up what the minified name is through the
+    // public method exposed for consumer use and reassign it below.
+    const minifiedShowInAppMessageName = appboy.display.showInAppMessage.prototype.constructor.name;
+
+    appboy.display.showInAppMessage = appboy.display[minifiedShowInAppMessageName] = function(inAppMessage) {
       const router = appInstance.get('router');
 
       // If the message or buttons within the message have a URI, we need

--- a/tests/unit/instance-initializers/appboy-test.js
+++ b/tests/unit/instance-initializers/appboy-test.js
@@ -31,7 +31,11 @@ module('Unit | Instance Initializer | appboy', {
       appboyOpenSession = sandbox.stub(appboy, 'openSession');
       appboyLogCustomEvent = sandbox.stub(appboy, 'logCustomEvent');
       appboyAutomaticallyShowNewInAppMessages = sandbox.stub();
-      appboy.display = { automaticallyShowNewInAppMessages: appboyAutomaticallyShowNewInAppMessages };
+      appboy.display = {
+        Fe: () => { throw new Error('Should be overriden!'); }, // simulate minification
+        automaticallyShowNewInAppMessages: appboyAutomaticallyShowNewInAppMessages
+      };
+      appboy.display.showInAppMessage = appboy.display.Fe; // simulate minification
       ouibounceStub = sandbox.stub();
       define('ouibounce', [], () => { return { default: ouibounceStub }; });
     });
@@ -92,4 +96,15 @@ test('it sets up the appboy callback on ouibounce if logExitIntent flag is set',
   const callback = ouibounceStub.getCall(0).args[1].callback;
   callback();
   assert.ok(appboyLogCustomEvent.withArgs('exit intent').calledOnce);
+});
+
+test('it rewires the minified showInAppMessage method', function(assert) {
+  // This is defined in the beforeEach to simulate minification
+  appboy.display.Fe = () => {
+    throw new Error('Minified function should never have been called!');
+  };
+
+  initialize(this.appInstance);
+
+  assert.expect(0); // thrown error would break this test
 });


### PR DESCRIPTION
Since appboy only distributes their minified source, internal methods trigger the minified flavor of showInAppMessage(), vs. the Ember-compatible one. To work around this, we need to see what they alias the public showInAppMessage() function to, and also override that method.
Fixes #13.
