### PR TITLE
Better URI handling.

### DIFF
--- a/addon/utils/url.js
+++ b/addon/utils/url.js
@@ -1,0 +1,18 @@
+// credit to @ronco
+// and https://gist.github.com/jlong/2428561
+export function parse(url) {
+  const parser = document.createElement('a');
+  parser.href = url;
+  // This api is very similar to node's url
+  return {
+    protocol: parser.protocol,
+    host: parser.host,
+    port: parser.port,
+    hostname: parser.hostname,
+    hash: parser.hash,
+    search: parser.search,
+    pathname: parser.pathname,
+    origin: parser.origin,
+    href: parser.href,
+  };
+}

--- a/tests/dummy/app/components/in-app-messages-example.js
+++ b/tests/dummy/app/components/in-app-messages-example.js
@@ -73,6 +73,21 @@ export default Ember.Component.extend({
     appboy.display.showInAppMessage(modal);
   },
 
+  showModalWithExternalLink() {
+    let modal = new appboy.ab.ModalMessage();
+    modal.header  = "Modal with Buttons";
+    modal.message = "This is a modal with a button that transitions outside the Ember App.";
+
+    let button1 = new appboy.ab.InAppMessage.Button();
+    button1.text = 'Example Route 1';
+    button1.clickAction = appboy.ab.InAppMessage.ClickAction.URI;
+    button1.uri = 'https://benlimmer.com';
+
+    modal.buttons = [button1];
+    disableAnimationInTest(modal);
+    appboy.display.showInAppMessage(modal);
+  },
+
   showFullWithOneButton() {
     let modal = new appboy.ab.FullScreenMessage();
     modal.header  = "Fullscreen Message with One Button";

--- a/tests/dummy/app/templates/components/in-app-messages-example.hbs
+++ b/tests/dummy/app/templates/components/in-app-messages-example.hbs
@@ -50,6 +50,12 @@
   Modal With Two Buttons Example
 {{/paper-button}}
 
+<br />
+
+{{#paper-button id='trigger-modal-with-external-link' raised=true onClick=(action showModalWithExternalLink)}}
+  Modal With External Link
+{{/paper-button}}
+
 <h3>Fullscreen In-App Messages</h3>
 {{#ember-markdown-section}}
   [Docs](https://www.appboy.com/documentation/Web/#full-in-app-messages)

--- a/tests/unit/utils/url-test.js
+++ b/tests/unit/utils/url-test.js
@@ -1,0 +1,41 @@
+import { parse } from 'ember-appboy/utils/url';
+import { module, test } from 'qunit';
+
+const url = 'https://imoscar.com:2/give-pop?pop=your#hair';
+
+let result;
+module('Unit | Utility | url', {
+  beforeEach() {
+    result = parse(url);
+  }
+});
+
+test("parses protocol", function(assert) {
+  assert.equal(result.protocol, 'https:');
+});
+test("parses host", function(assert) {
+  assert.equal(result.host, 'imoscar.com:2');
+});
+test("parses port", function(assert) {
+  assert.equal(result.port, '2');
+});
+test("parses hostname", function(assert) {
+  assert.equal(result.hostname, 'imoscar.com');
+});
+test("parses hash", function(assert) {
+  assert.equal(result.hash, '#hair');
+});
+test("parses search", function(assert) {
+  assert.equal(result.search, '?pop=your');
+});
+test("parses pathname", function(assert) {
+  assert.equal(result.pathname, '/give-pop');
+});
+test("parses origin", function(assert) {
+  assert.equal(result.origin, 'https://imoscar.com:2');
+});
+
+test("handles undefined", function(assert) {
+  let undefinedResult = parse();
+  assert.equal(typeof undefinedResult, 'object');
+});


### PR DESCRIPTION
For now, I assume if it's the same hostname you're transitioning to,
that it's a route in your ember application and will ask the router to
handle a soft transition. If it's a link to somewhere else, I allow
appboy to handle the hard transition normally.
Fixes #12.
