### PR TITLE
Test external linking in-app messages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "appboy-web-sdk"
   ],
   "dependencies": {
-    "appboy-web-sdk": "^1.5.1",
+    "appboy-web-sdk": "^1.6.0",
     "broccoli-funnel": "^1.0.6",
     "broccoli-merge-trees": "^1.1.4",
     "ember-cli-babel": "^5.1.6",

--- a/tests/acceptance/in-app-messages-test.js
+++ b/tests/acceptance/in-app-messages-test.js
@@ -1,5 +1,6 @@
-import { test } from 'qunit';
+import test from 'dummy/tests/ember-sinon-qunit/test';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import appboy from 'appboy';
 
 moduleForAcceptance('Acceptance | in app messages');
 
@@ -52,5 +53,22 @@ test('modals with two button ClickActions handle transition correctly - second b
   click('.ab-message-button:nth-of-type(2)', 'body');
   andThen(function() {
     assert.equal(currentURL(), '/in-app-messages/example-2');
+  });
+});
+
+test('modals with external links', function(assert) {
+  const prevOpenUri = appboy.ab.WindowUtils.openUri;
+  appboy.ab.WindowUtils.openUri = this.sandbox.stub();
+
+  visit('/in-app-messages');
+  click('#trigger-modal-with-external-link');
+  andThen(function() {
+    let $el = findWithAssert('.ab-in-app-message', 'body');
+    assert.equal($el.length, 1);
+  });
+  click('.ab-message-button', 'body');
+  andThen(function() {
+    assert.ok(appboy.ab.WindowUtils.openUri.withArgs('https://benlimmer.com').calledOnce);
+    appboy.ab.WindowUtils.openUri = prevOpenUri;
   });
 });


### PR DESCRIPTION
Appboy 1.6.x exposes the method they use to change `window.location` so
we can stub and test it.
Resolves #16.
