### PR TITLE
Work around undefined IAM.buttons.

### DIFF
--- a/addon/instance-initializers/appboy.js
+++ b/addon/instance-initializers/appboy.js
@@ -49,6 +49,7 @@ export function initialize(appInstance) {
       // to grab the URI and hide it from appboy to do a "soft" transition
       // with the Ember Router vs. an anchor tag, which causes the app to
       // refresh when clicked.
+      inAppMessage.buttons = inAppMessage.buttons || [];
       [inAppMessage, ...inAppMessage.buttons].forEach(function(item) {
         if (item.clickAction === ClickAction.URI && item.uri) {
           const routerPath = getAppRoute(item.uri);

--- a/tests/acceptance/in-app-messages-test.js
+++ b/tests/acceptance/in-app-messages-test.js
@@ -72,3 +72,12 @@ test('modals with external links', function(assert) {
     appboy.ab.WindowUtils.openUri = prevOpenUri;
   });
 });
+
+test('modals with undefined button arrays', function(assert) {
+  visit('/in-app-messages');
+  click('#trigger-modal-with-undefined-buttons');
+  andThen(function() {
+    let $el = findWithAssert('.ab-in-app-message', 'body');
+    assert.equal($el.length, 1);
+  });
+});

--- a/tests/dummy/app/components/in-app-messages-example.js
+++ b/tests/dummy/app/components/in-app-messages-example.js
@@ -12,6 +12,10 @@ function disableAnimationInTest(item) {
 export default Ember.Component.extend({
   layout,
 
+  isTestEnv: Ember.computed(function() {
+    return ENV.environment === 'test';
+  }),
+
   showSlideUpMessage() {
     let message = new appboy.ab.SlideUpMessage(
       "This is a Slide-Up In-App Message!"
@@ -24,6 +28,16 @@ export default Ember.Component.extend({
     let modal = new appboy.ab.ModalMessage();
     modal.header  = "Woah, there...";
     modal.message = "Doing this might be a terrible idea but ,idk, here's a modal to make you think twice.";
+    disableAnimationInTest(modal);
+    appboy.display.showInAppMessage(modal);
+  },
+
+  // see https://github.com/blimmer/ember-appboy/issues/35
+  showModalWithUndefinedButtons() {
+    let modal = new appboy.ab.ModalMessage();
+    modal.header  = "Woah, there...";
+    modal.message = "Doing this might be a terrible idea but ,idk, here's a modal to make you think twice.";
+    modal.buttons = undefined;
     disableAnimationInTest(modal);
     appboy.display.showInAppMessage(modal);
   },

--- a/tests/dummy/app/templates/components/in-app-messages-example.hbs
+++ b/tests/dummy/app/templates/components/in-app-messages-example.hbs
@@ -32,6 +32,13 @@
   Modal Example
 {{/paper-button}}
 
+{{#if isTestEnv}}
+  {{! no need to show this to consumers of the docs }}
+  {{#paper-button id='trigger-modal-with-undefined-buttons' raised=true onClick=(action showModalWithUndefinedButtons)}}
+    Undefined Button Modal Example
+  {{/paper-button}}
+{{/if}}
+
 <br />
 
 {{#paper-button id='trigger-modal-with-transition' raised=true onClick=(action showModalWithTransition)}}


### PR DESCRIPTION
It seems like maybe the default `super` implementation of this is setting the default, which our custom transition code is not tolerant of.
When babel transpiles the splat of the array, it is not tolerant of null / undefined values.
This commit fixes #35.